### PR TITLE
Enhance TPA commands to match functionality of EssentialsX with easier usage

### DIFF
--- a/src/main/java/me/drex/essentials/command/impl/tpa/TpAcceptCommand.java
+++ b/src/main/java/me/drex/essentials/command/impl/tpa/TpAcceptCommand.java
@@ -67,7 +67,7 @@ public class TpAcceptCommand extends Command {
             return FAILURE;
         }
         
-        TpaManager.Participants participants = requests.get(0);
+        TpaManager.Participants participants = requests.getFirst();
         ServerPlayer target = ctx.getSource().getServer().getPlayerList().getPlayer(participants.requester());
         if (target == null) {
             ctx.getSource().sendFailure(localized("fabric-essentials.commands.tpaccept.player_offline"));

--- a/src/main/java/me/drex/essentials/command/impl/tpa/TpAcceptCommand.java
+++ b/src/main/java/me/drex/essentials/command/impl/tpa/TpAcceptCommand.java
@@ -6,6 +6,7 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import eu.pb4.placeholders.api.PlaceholderContext;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.server.level.ServerPlayer;
 import me.drex.essentials.command.Command;
 import me.drex.essentials.command.CommandProperties;
@@ -14,7 +15,6 @@ import me.drex.essentials.util.ComponentPlaceholderUtil;
 import me.drex.essentials.util.TeleportCancelException;
 import me.drex.essentials.util.TpaManager;
 import me.drex.essentials.util.teleportation.Location;
-import com.mojang.brigadier.arguments.StringArgumentType;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -36,18 +36,9 @@ public class TpAcceptCommand extends Command {
     protected void registerArguments(LiteralArgumentBuilder<CommandSourceStack> literal, CommandBuildContext commandBuildContext) {
         literal.executes(this::executeNoArg)
         .then(
-                argument(TARGET_ARGUMENT_ID, StringArgumentType.word())
-                        .suggests((context, builder) -> {
-                            String input = builder.getRemaining().toLowerCase();
-                            context.getSource().getServer().getPlayerList().getPlayers().stream()
-                                .map(player -> player.getGameProfile().getName())
-                                .filter(name -> name.toLowerCase().startsWith(input))
-                                .forEach(builder::suggest);
-                            return builder.buildFuture();
-                        })
+                argument(TARGET_ARGUMENT_ID, EntityArgument.player())
                         .executes(ctx -> {
-                            String partialName = StringArgumentType.getString(ctx, TARGET_ARGUMENT_ID);
-                            ServerPlayer target = TpaCommand.findPlayerByPartialName(ctx.getSource(), partialName);
+                            ServerPlayer target = EntityArgument.getPlayer(ctx, TARGET_ARGUMENT_ID);
                             return execute(ctx, target);
                         })
         );

--- a/src/main/java/me/drex/essentials/command/impl/tpa/TpDenyCommand.java
+++ b/src/main/java/me/drex/essentials/command/impl/tpa/TpDenyCommand.java
@@ -6,11 +6,11 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import eu.pb4.placeholders.api.PlaceholderContext;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.server.level.ServerPlayer;
 import me.drex.essentials.command.Command;
 import me.drex.essentials.command.CommandProperties;
 import me.drex.essentials.util.TpaManager;
-import com.mojang.brigadier.arguments.StringArgumentType;
 
 import static me.drex.message.api.LocalizedMessage.localized;
 import static net.minecraft.commands.Commands.argument;
@@ -29,18 +29,9 @@ public class TpDenyCommand extends Command {
     protected void registerArguments(LiteralArgumentBuilder<CommandSourceStack> literal, CommandBuildContext commandBuildContext) {
         literal.executes(this::executeNoArg)
         .then(
-                argument(TARGET_ARGUMENT_ID, StringArgumentType.word())
-                        .suggests((context, builder) -> {
-                            String input = builder.getRemaining().toLowerCase();
-                            context.getSource().getServer().getPlayerList().getPlayers().stream()
-                                .map(player -> player.getGameProfile().getName())
-                                .filter(name -> name.toLowerCase().startsWith(input))
-                                .forEach(builder::suggest);
-                            return builder.buildFuture();
-                        })
+                argument(TARGET_ARGUMENT_ID, EntityArgument.player())
                         .executes(ctx -> {
-                            String partialName = StringArgumentType.getString(ctx, TARGET_ARGUMENT_ID);
-                            ServerPlayer target = TpaCommand.findPlayerByPartialName(ctx.getSource(), partialName);
+                            ServerPlayer target = EntityArgument.getPlayer(ctx, TARGET_ARGUMENT_ID);
                             return execute(ctx, target);
                         })
         );

--- a/src/main/java/me/drex/essentials/command/impl/tpa/TpaCommand.java
+++ b/src/main/java/me/drex/essentials/command/impl/tpa/TpaCommand.java
@@ -15,11 +15,8 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 
 import static me.drex.message.api.LocalizedMessage.localized;
 import static net.minecraft.commands.Commands.argument;
-import static net.minecraft.commands.arguments.EntityArgument.getPlayer;
-import static net.minecraft.commands.arguments.EntityArgument.player;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class TpaCommand extends Command {
 
@@ -69,7 +66,7 @@ public class TpaCommand extends Command {
         String lowercasePartial = partialName.toLowerCase();
         List<ServerPlayer> matches = source.getServer().getPlayerList().getPlayers().stream()
                 .filter(player -> player.getGameProfile().getName().toLowerCase().startsWith(lowercasePartial))
-                .collect(Collectors.toList());
+                .toList();
 
         if (matches.isEmpty()) {
             throw new SimpleCommandExceptionType(
@@ -81,7 +78,7 @@ public class TpaCommand extends Command {
                 Component.literal("Multiple players found matching '" + partialName + "'"))
                 .create();
         }
-        return matches.get(0);
+        return matches.getFirst();
     }
 
 }

--- a/src/main/java/me/drex/essentials/command/impl/tpa/TpaCommand.java
+++ b/src/main/java/me/drex/essentials/command/impl/tpa/TpaCommand.java
@@ -6,17 +6,13 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import eu.pb4.placeholders.api.PlaceholderContext;
 import net.minecraft.commands.CommandBuildContext;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.server.level.ServerPlayer;
 import me.drex.essentials.command.Command;
 import me.drex.essentials.util.TpaManager;
-import com.mojang.brigadier.arguments.StringArgumentType;
-import net.minecraft.network.chat.Component;
-import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 
 import static me.drex.message.api.LocalizedMessage.localized;
 import static net.minecraft.commands.Commands.argument;
-
-import java.util.List;
 
 public class TpaCommand extends Command {
 
@@ -34,22 +30,13 @@ public class TpaCommand extends Command {
     @Override
     protected void registerArguments(LiteralArgumentBuilder<CommandSourceStack> literal, CommandBuildContext commandBuildContext) {
         literal.then(
-                argument(TARGET_ARGUMENT_ID, StringArgumentType.word())
-                        .suggests((context, builder) -> {
-                            String input = builder.getRemaining().toLowerCase();
-                            context.getSource().getServer().getPlayerList().getPlayers().stream()
-                                .map(player -> player.getGameProfile().getName())
-                                .filter(name -> name.toLowerCase().startsWith(input))
-                                .forEach(builder::suggest);
-                            return builder.buildFuture();
-                        })
+                argument(TARGET_ARGUMENT_ID, EntityArgument.player())
                         .executes(this::execute)
         );
     }
 
     private int execute(CommandContext<CommandSourceStack> ctx) throws CommandSyntaxException {
-        String partialName = StringArgumentType.getString(ctx, TARGET_ARGUMENT_ID);
-        ServerPlayer target = findPlayerByPartialName(ctx.getSource(), partialName);
+        ServerPlayer target = EntityArgument.getPlayer(ctx, TARGET_ARGUMENT_ID);
         TpaManager.Participants participants = new TpaManager.Participants(ctx.getSource().getPlayerOrException().getUUID(), target.getUUID());
         TpaManager.Direction direction = TpaManager.INSTANCE.getRequest(participants);
         if (direction == this.direction) {
@@ -60,25 +47,6 @@ public class TpaCommand extends Command {
         ctx.getSource().sendSuccess(() -> localized("fabric-essentials.commands." + this.direction.getTranslationKey() + ".self", PlaceholderContext.of(target)), false);
         target.sendSystemMessage(localized("fabric-essentials.commands." + this.direction.getTranslationKey() + ".victim", PlaceholderContext.of(ctx.getSource())));
         return SUCCESS;
-    }
-
-    protected static ServerPlayer findPlayerByPartialName(CommandSourceStack source, String partialName) throws CommandSyntaxException {
-        String lowercasePartial = partialName.toLowerCase();
-        List<ServerPlayer> matches = source.getServer().getPlayerList().getPlayers().stream()
-                .filter(player -> player.getGameProfile().getName().toLowerCase().startsWith(lowercasePartial))
-                .toList();
-
-        if (matches.isEmpty()) {
-            throw new SimpleCommandExceptionType(
-                Component.literal("No player found matching '" + partialName + "'"))
-                .create();
-        }
-        if (matches.size() > 1) {
-            throw new SimpleCommandExceptionType(
-                Component.literal("Multiple players found matching '" + partialName + "'"))
-                .create();
-        }
-        return matches.getFirst();
     }
 
 }

--- a/src/main/java/me/drex/essentials/config/Config.java
+++ b/src/main/java/me/drex/essentials/config/Config.java
@@ -1,5 +1,6 @@
 package me.drex.essentials.config;
 
+import me.drex.essentials.config.commands.CommandsConfig;
 import me.drex.essentials.config.homes.HomesConfig;
 import me.drex.essentials.config.teleportation.TeleportationConfig;
 import me.drex.essentials.config.tpa.TpaConfig;
@@ -9,6 +10,8 @@ public class Config {
     public HomesConfig homes = new HomesConfig();
 
     public TpaConfig tpa = new TpaConfig();
+
+    public CommandsConfig commands = new CommandsConfig();
 
     public TeleportationConfig teleportation = new TeleportationConfig();
 

--- a/src/main/java/me/drex/essentials/config/commands/CommandsConfig.java
+++ b/src/main/java/me/drex/essentials/config/commands/CommandsConfig.java
@@ -1,0 +1,7 @@
+package me.drex.essentials.config.commands;
+
+public class CommandsConfig {
+
+    public boolean allowPartialNames = false;
+
+}

--- a/src/main/java/me/drex/essentials/mixin/command/EntitySelectorMixin.java
+++ b/src/main/java/me/drex/essentials/mixin/command/EntitySelectorMixin.java
@@ -1,0 +1,50 @@
+package me.drex.essentials.mixin.command;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import me.drex.essentials.config.ConfigManager;
+import net.minecraft.commands.arguments.selector.EntitySelector;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.PlayerList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.List;
+
+@Mixin(EntitySelector.class)
+public abstract class EntitySelectorMixin {
+
+    @WrapOperation(
+        method = "findPlayers",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/server/players/PlayerList;getPlayerByName(Ljava/lang/String;)Lnet/minecraft/server/level/ServerPlayer;"
+        )
+    )
+    public ServerPlayer allowPartialName(PlayerList playerList, String input, Operation<ServerPlayer> original) throws CommandSyntaxException {
+        if (ConfigManager.config().commands.allowPartialNames) {
+            String lowercasePartial = input.toLowerCase();
+            List<ServerPlayer> matches = playerList.getPlayers().stream()
+                .filter(player -> player.getGameProfile().getName().toLowerCase().startsWith(lowercasePartial))
+                .toList();
+
+            if (matches.isEmpty()) {
+                throw new SimpleCommandExceptionType(
+                    Component.literal("No player found matching '" + input + "'"))
+                    .create();
+            }
+            if (matches.size() > 1) {
+                throw new SimpleCommandExceptionType(
+                    Component.literal("Multiple players found matching '" + input + "'"))
+                    .create();
+            }
+            return matches.getFirst();
+        } else {
+            return original.call(playerList, input);
+        }
+    }
+
+}

--- a/src/main/java/me/drex/essentials/util/TpaManager.java
+++ b/src/main/java/me/drex/essentials/util/TpaManager.java
@@ -72,9 +72,8 @@ public class TpaManager {
     }
 
     public List<Participants> getRequestsFor(UUID target) {
-        return requestMap.entrySet().stream()
-            .filter(entry -> entry.getKey().requested().equals(target))
-            .map(Map.Entry::getKey)
+        return requestMap.keySet().stream()
+            .filter(request -> request.requested().equals(target))
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/me/drex/essentials/util/TpaManager.java
+++ b/src/main/java/me/drex/essentials/util/TpaManager.java
@@ -10,8 +10,6 @@ import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 public class TpaManager {
 
@@ -74,7 +72,7 @@ public class TpaManager {
     public List<Participants> getRequestsFor(UUID target) {
         return requestMap.keySet().stream()
             .filter(request -> request.requested().equals(target))
-            .collect(Collectors.toList());
+            .toList();
     }
 
 }

--- a/src/main/java/me/drex/essentials/util/TpaManager.java
+++ b/src/main/java/me/drex/essentials/util/TpaManager.java
@@ -9,6 +9,9 @@ import me.drex.essentials.config.ConfigManager;
 import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class TpaManager {
 
@@ -66,6 +69,13 @@ public class TpaManager {
     }
 
     public record Request(Direction direction, long timeStamp) {
+    }
+
+    public List<Participants> getRequestsFor(UUID target) {
+        return requestMap.entrySet().stream()
+            .filter(entry -> entry.getKey().requested().equals(target))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
     }
 
 }

--- a/src/main/resources/essentials.mixins.json
+++ b/src/main/resources/essentials.mixins.json
@@ -15,6 +15,7 @@
     "async.IChunkMap",
     "async.IServerChunkCache",
     "async.ServerPlayerMixin",
+    "command.EntitySelectorMixin",
     "spy.ServerGamePacketListenerImplMixin",
     "style.AnvilMenuMixin",
     "style.ServerGamePacketListenerImplMixin",

--- a/src/main/resources/messages/en_us.json
+++ b/src/main/resources/messages/en_us.json
@@ -135,5 +135,13 @@
   "fabric-essentials.teleport.cancel.other": "<dark_red>%player:displayname% <red>cancelled the teleportation!",
   "fabric-essentials.teleport.cancel.move": "<red>Teleportation cancelled. You moved too far!",
   "fabric-essentials.teleport.cancel.damage": "<red>Teleportation cancelled. You received damage!",
-  "fabric-essentials.teleport.cancel.unknown": "<red>Teleportation cancelled."
+  "fabric-essentials.teleport.cancel.unknown": "<red>Teleportation cancelled.",
+
+  "fabric-essentials.commands.tpaccept.no_requests": "<red>You have no pending teleport requests",
+  "fabric-essentials.commands.tpaccept.multiple_requests": "<red>You have multiple pending requests. Please specify a player",
+  "fabric-essentials.commands.tpaccept.player_offline": "<red>The player who sent the request is no longer online",
+  
+  "fabric-essentials.commands.tpdeny.no_requests": "<red>You have no pending teleport requests",
+  "fabric-essentials.commands.tpdeny.multiple_requests": "<red>You have multiple pending requests. Please specify a player",
+  "fabric-essentials.commands.tpdeny.player_offline": "<red>The player who sent the request is no longer online"
 }

--- a/src/main/resources/messages/zh_hk.json
+++ b/src/main/resources/messages/zh_hk.json
@@ -135,5 +135,13 @@
   "fabric-essentials.teleport.cancel.other": "<dark_red>%player:displayname%<red>取消咗傳送！",
   "fabric-essentials.teleport.cancel.move": "<red>傳送取消咗。你行得太遠啦！",
   "fabric-essentials.teleport.cancel.damage": "<red>傳送取消咗。你受到咗傷害！",
-  "fabric-essentials.teleport.cancel.unknown": "<red>傳送取消咗。"
+  "fabric-essentials.teleport.cancel.unknown": "<red>傳送取消咗。",
+
+  "fabric-essentials.commands.tpaccept.no_requests": "<red>你冇等緊嘅傳送請求",
+  "fabric-essentials.commands.tpaccept.multiple_requests": "<red>你有多個等緊嘅請求。請指定一個玩家",
+  "fabric-essentials.commands.tpaccept.player_offline": "<red>發送請求嘅玩家已經離線",
+  
+  "fabric-essentials.commands.tpdeny.no_requests": "<red>你冇等緊嘅傳送請求",
+  "fabric-essentials.commands.tpdeny.multiple_requests": "<red>你有多個等緊嘅請求。請指定一個玩家",
+  "fabric-essentials.commands.tpdeny.player_offline": "<red>發送請求嘅玩家已經離線"
 }

--- a/src/main/resources/messages/zh_tw.json
+++ b/src/main/resources/messages/zh_tw.json
@@ -135,5 +135,13 @@
   "fabric-essentials.teleport.cancel.other": "<dark_red>%player:displayname%<red>取消了傳送！",
   "fabric-essentials.teleport.cancel.move": "<red>傳送取消了。你走得太遠了！",
   "fabric-essentials.teleport.cancel.damage": "<red>傳送取消了。你受到了傷害！",
-  "fabric-essentials.teleport.cancel.unknown": "<red>傳送取消了。"
+  "fabric-essentials.teleport.cancel.unknown": "<red>傳送取消了。",
+
+  "fabric-essentials.commands.tpaccept.no_requests": "<red>你沒有待處理的傳送請求",
+  "fabric-essentials.commands.tpaccept.multiple_requests": "<red>你有多個待處理的請求。請指定一個玩家",
+  "fabric-essentials.commands.tpaccept.player_offline": "<red>發送請求的玩家已離線",
+  
+  "fabric-essentials.commands.tpdeny.no_requests": "<red>你沒有待處理的傳送請求",
+  "fabric-essentials.commands.tpdeny.multiple_requests": "<red>你有多個待處理的請求。請指定一個玩家",
+  "fabric-essentials.commands.tpdeny.player_offline": "<red>發送請求的玩家已離線"
 }


### PR DESCRIPTION
Enhance TPA commands to match functionality of EssentialsX with easier usage

This code has been roughly tested on my computer and it works. 

- Updated TpAcceptCommand and TpDenyCommand to support player name suggestions using StringArgumentType.
- Implemented logic to handle multiple and no pending teleport requests, providing user feedback for each case.
- Added a method in TpaCommand to find players by partial names.
- Updated TpaManager to retrieve requests for a specific player.
- Updated localized messages.